### PR TITLE
[ESLint] specify React version

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,11 @@
     "process": true,
     "Buffer": true
   },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
   "rules": {
     "indent": [
       "error",


### PR DESCRIPTION
To avoid the warning below specified the "version" so that ESLint detects React version which have installed.

```
$ yarn lint
> yarn run v1.15.2
> $ eslint app
> Warning: React version not specified in eslint-plugin-react settings. See https://github.com/yannickcr/eslint-plugin-react#configuration .
```

